### PR TITLE
Add exit routine to ECL implementation

### DIFF
--- a/src/main.lisp
+++ b/src/main.lisp
@@ -78,7 +78,8 @@
   `print-error-and-exit` if it's not implemented for your particular Lisp.
 
   "
-  #-(or sbcl ccl abcl lispworks) (error "~S is not supported on this implementation." 'exit)
+  #-(or ecl sbcl ccl abcl lispworks) (error "~S is not supported on this implementation." 'exit)
+  #+ecl (si:exit code)
   #+sbcl (sb-ext:exit :code code)
   #+ccl (ccl:quit code)
   #+abcl (ext:quit :status code)


### PR DESCRIPTION
Use `(si:exit code)` in ECL.