### PR TITLE
Optionally treat first top-level argument as an implicit terminator

### DIFF
--- a/docs/01-usage.markdown
+++ b/docs/01-usage.markdown
@@ -375,7 +375,12 @@ do not take any parameters, they can be mashed together and given all at once
 argument (`-n foo`) or mashed together with the option `-nfoo`.
 
 The special string `--` signals that all remaining arguments are normal text
-arguments, and should not be parsed as options.
+arguments, and should not be parsed as options. The same can be signalled using
+other strings if a function is passed with the `:custom-terminatorp` keyword
+argument of `adopt:make-interface`. Arguments not associated with any option
+will be passed to this function, and if a non-nil value results, parsing will be
+terminated. Note that while the string `--` is not returned alongside other non-
+option arguments, custom terminator strings are.
 
 Top-Level Structure
 -------------------

--- a/src/main.lisp
+++ b/src/main.lisp
@@ -557,7 +557,7 @@
   (invoke-restart (find-restart 'supply-new-value condition) value))
 
 
-(defun parse-options (interface &optional (arguments (rest (argv))))
+(defun parse-options (interface &optional (arguments (rest (argv))) stop-at-first-toplevel)
   "Parse `arguments` according to `interface`.
 
   Two values are returned:
@@ -584,7 +584,10 @@
                        ((terminatorp arg) (dolist (r remaining) (push r toplevel)))
                        ((shortp arg) (parse-short interface results arg remaining))
                        ((longp arg) (parse-long interface results arg remaining))
-                       (t (push arg toplevel) remaining))
+                       (t (push arg toplevel)
+			  (if stop-at-first-toplevel
+			      (cons "--" remaining)
+			      remaining)))
                    (discard-option ()
                      :test unrecognized-option-p
                      :report "Discard the unrecognized option."
@@ -601,7 +604,7 @@
                      (cons v remaining))))))))
       (recur arguments))))
 
-(defun parse-options-or-exit (interface &optional (arguments (rest (argv))))
+(defun parse-options-or-exit (interface &optional (arguments (rest (argv))) stop-at-first-toplevel)
   "Parse `arguments` according to `interface`, exiting if any error occurs.
 
   Two values are returned:
@@ -616,7 +619,7 @@
   See the full documentation for more information.
 
   "
-  (handler-case (adopt:parse-options interface arguments)
+  (handler-case (adopt:parse-options interface arguments stop-at-first-toplevel)
     (error (c) (adopt:print-error-and-exit c))))
 
 

--- a/src/main.lisp
+++ b/src/main.lisp
@@ -173,7 +173,7 @@
   * `reduce` (**required**): a function designator that will be called every time the option is specified by the user.
   * `initial-value` (optional): a value to use as the initial value of the option.
   * `key` (optional): a function designator, only allowed for parameter-taking options, to be called on the values given by the user before they are passed along to the reducing function.  It will not be called on the initial value.
-  * `finally` (optional): a function designator to be called on the final result after all parsing is complete. 
+  * `finally` (optional): a function designator to be called on the final result after all parsing is complete.
 
   The manner in which the reducer is called depends on whether the option takes a parameter:
 
@@ -376,6 +376,7 @@
   groups
   short-options
   long-options
+  custom-terminatorp
   usage
   help
   manual)
@@ -387,7 +388,7 @@
             (length (options i))
             (length (groups i)))))
 
-(defun make-interface (&key name summary usage help manual examples contents)
+(defun make-interface (&key name summary usage help manual examples contents custom-terminatorp)
   "Create and return a command line interface.
 
   This function takes a number of arguments that define how the interface is
@@ -400,6 +401,7 @@
   * `manual` (optional): a string to use in place of `help` when rendering a man page.
   * `examples` (optional): an alist of `(prose . command)` conses to render as a list of examples.
   * `contents` (optional): a list of options and groups.  Ungrouped options will be collected into a single top-level group.
+  * `custom-terminatorp` (optional): a function to be called on toplevel arguments. If it returns non-nil, the current and all remaining arguments will be returned as toplevel.
 
   See the full documentation for more information.
 
@@ -425,7 +427,8 @@
                       :groups groups
                       :options options
                       :short-options (make-hash-table)
-                      :long-options (make-hash-table :test #'equal))))
+                      :long-options (make-hash-table :test #'equal)
+                      :custom-terminatorp custom-terminatorp)))
     (flet ((add-option (option)
              (let ((short (short option))
                    (long (long option)))
@@ -557,7 +560,7 @@
   (invoke-restart (find-restart 'supply-new-value condition) value))
 
 
-(defun parse-options (interface &optional (arguments (rest (argv))) stop-at-first-toplevel)
+(defun parse-options (interface &optional (arguments (rest (argv))))
   "Parse `arguments` according to `interface`.
 
   Two values are returned:
@@ -570,7 +573,8 @@
 
   "
   (let ((toplevel nil)
-        (results (make-hash-table)))
+        (results (make-hash-table))
+        (custom-terminatorp (custom-terminatorp interface)))
     (initialize-results interface results)
     (labels
         ((recur (arguments)
@@ -585,9 +589,10 @@
                        ((shortp arg) (parse-short interface results arg remaining))
                        ((longp arg) (parse-long interface results arg remaining))
                        (t (push arg toplevel)
-			  (if stop-at-first-toplevel
-			      (cons "--" remaining)
-			      remaining)))
+                          (if (and custom-terminatorp
+                                   (funcall custom-terminatorp arg))
+                              (cons "--" remaining)
+                              remaining)))
                    (discard-option ()
                      :test unrecognized-option-p
                      :report "Discard the unrecognized option."
@@ -604,7 +609,7 @@
                      (cons v remaining))))))))
       (recur arguments))))
 
-(defun parse-options-or-exit (interface &optional (arguments (rest (argv))) stop-at-first-toplevel)
+(defun parse-options-or-exit (interface &optional (arguments (rest (argv))))
   "Parse `arguments` according to `interface`, exiting if any error occurs.
 
   Two values are returned:
@@ -619,7 +624,7 @@
   See the full documentation for more information.
 
   "
-  (handler-case (adopt:parse-options interface arguments stop-at-first-toplevel)
+  (handler-case (adopt:parse-options interface arguments)
     (error (c) (adopt:print-error-and-exit c))))
 
 


### PR DESCRIPTION
Some commands, `time` and `watch` for example, treat their first non-hyphenated arguments as names of commands and their remaining arguments as to be passed to those commands. Currently this is not possible in Adopt, but this commit, by simply adding another optional argument to `parse-options`, makes it possible  .
Perhaps there is a more elegant way of doing this. This commit will force the user to pass a value for the `arguments` parameter in `parse-options` (and thus `parse-options-or-exit`) if they wish to parse options in the `time`/`watch` style. 